### PR TITLE
Dump errors to $stderr on the server side

### DIFF
--- a/ruby/lib/msgpack/rpc/server.rb
+++ b/ruby/lib/msgpack/rpc/server.rb
@@ -106,8 +106,11 @@ class Server < SessionPool
 		#FIXME on ArgumentError
 		# res.error(ArgumentError); return
 
-		rescue
-			responder.error($!.to_s)
+ 		rescue => e
+			btrace = e.backtrace
+			btrace[0] = "#{btrace[0]}: #{e.message} (#{e.class})"
+			$stderr.puts btrace.join("\n\tfrom: ")
+			responder.error(e.message)
 			return
 		end
 


### PR DESCRIPTION
Currently it is difficult to identify the source of an error in server-side code. This commits writes backtraces in a familiar format to $stderr, making it easier to locate the origin of server-side exceptions.
