### PR TITLE
Marshal-mode (transparent Marshal.dump/load)

### DIFF
--- a/ruby/lib/msgpack/rpc.rb
+++ b/ruby/lib/msgpack/rpc.rb
@@ -167,10 +167,6 @@ module MessagePack  #:nodoc:
 #   end
 #
 #
-# You can receive and send any objects that can be serialized by MessagePack.
-# This means that the objects required to implement *to_msgpack(out = '')* method.
-#
-#
 # == Transports
 #
 # You can use UDP and UNIX domain sockets instead of TCP.
@@ -225,6 +221,25 @@ module MessagePack  #:nodoc:
 #   server.run
 #
 #
+# == Serialization
+# 
+# By default you can receive and send any objects that can be serialized by MessagePack.
+# This means that the objects required to implement *to_msgpack(out = '')* method.
+#
+#
+# === Marshal Mode
+#
+# Alternatively you may use MessagePack::RPC::Marshal::Client,
+# MessagePack::RPC::Marshal::SessionPool and MessagePack::RPC::Marshal::Server
+# instead of the regular Client/Server/SessionPool.
+#
+# These classes will transparently marshall all method parameters and
+# return values on the sender side and unmarshall on the receiver side
+#
+# This means you can pass instances of custom classes back and forth
+# without implementing *to_msgpack(out = '')* or doing manual serialization.
+# All classes that you want to exchange must exist on both sides.
+#
 module RPC
 end
 
@@ -248,4 +263,5 @@ require 'msgpack/rpc/client'
 require 'msgpack/rpc/server'
 require 'msgpack/rpc/transport/base'
 require 'msgpack/rpc/transport/tcp'
+require 'msgpack/rpc/marshal'
 

--- a/ruby/lib/msgpack/rpc/marshal.rb
+++ b/ruby/lib/msgpack/rpc/marshal.rb
@@ -1,0 +1,99 @@
+#
+# MessagePack-RPC for Ruby
+#
+# Copyright (C) 2010-2011 FURUHASHI Sadayuki
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+# Marshal mode contributed by moe@morepanda.net
+
+module MessagePack
+module RPC
+module Marshal
+
+#
+# == Marshal Mode
+#
+# In Marshal mode any object that can be marshalled may be used
+# as a method parameter or return value. The objects are transparently
+# marshalled on the sender side and unmarshalled on the receiver side.
+#
+# This frees you from having to manually serialize/deserialize your
+# objects when both of your endpoints are running in this mode.
+#
+# === Usage
+#
+# Usage is identical to regular msgpack-rpc.
+# 
+# Just use MessagePack::RPC::Marshal::Client, MessagePack::RPC::Marshal::SessionPool
+# and MessagePack::RPC::Marshal::Server instead of the normal RPC::Client/Server/SessionPool.
+#
+
+class Client < RPC::Client
+  def send_request(method, param)
+    super method, ::Marshal.dump(param)
+  end
+
+  def on_response(sock, msgid, error, result)  #:nodoc:
+    result = ::Marshal.load(result) unless result.nil?
+    result = super(sock, msgid, error, result)
+  end
+end
+
+class SessionPool < RPC::SessionPool
+	# 1. get_session(address)
+	# 2. get_session(host, port)
+	#
+	# Returns pooled Session.
+	# If there are no pooled Session for the specified address,
+	# this method creates the Session and pools it.
+	def get_session(arg1, arg2=nil)
+		if arg2.nil?
+			# 1.
+			addr = arg1
+		else
+			# 2.
+			host = arg1
+			port = arg2
+			addr = Address.new(host, port)
+		end
+
+    # Create Marshal::Client instead of plain Session
+		@pool[addr] ||= Marshal::Client.new(@builder, addr, @loop)
+	end
+end
+
+class MarshalledResponder < Responder
+  def initialize(proxy_me)
+    @proxied = proxy_me
+  end
+
+	def result(retval, err = nil)
+    @proxied.result ::Marshal.dump(retval), err
+  end
+end
+
+class Server < RPC::Server
+	# from ServerTransport
+	def on_request(sendable, msgid, method, param)  #:nodoc:
+		responder = MarshalledResponder.new( Responder.new(sendable, msgid) )
+		dispatch_method(method, ::Marshal.load(param), responder)
+	end
+end
+
+end
+end
+end
+
+

--- a/ruby/test/msgpack_rpc_marshal_test.rb
+++ b/ruby/test/msgpack_rpc_marshal_test.rb
@@ -1,0 +1,67 @@
+#!/usr/bin/env ruby
+
+require File.expand_path(File.dirname(__FILE__)) + '/test_helper.rb'
+require File.expand_path(File.dirname(__FILE__)) + '/msgpack_rpc_test.rb'
+
+
+p
+$port = 65500
+
+class MessagePackRPCMarshalTest < Test::Unit::TestCase
+  include MessagePackRPCTestBase
+
+  def setup
+    @server_cls = MessagePack::RPC::Marshal::Server
+    @client_cls = MessagePack::RPC::Marshal::Client
+  end
+
+	def test_pool
+    # Overrides the default pool test to use
+    # RPC::Marshal::SessionPool instead of the normal RPC::SessionPool
+		svr, cli = start_server
+
+		sp = MessagePack::RPC::Marshal::SessionPool.new
+		s = sp.get_session('127.0.0.1', cli.port)
+
+		result = s.call(:hello)
+		assert_equal(result, "ok")
+
+		result = s.call(:sum, 1, 2)
+		assert_equal(result, 3)
+
+		sp.close
+		cli.close
+		svr.stop
+	end
+
+	def test_echo_marshal
+		svr, cli = start_server
+
+		result = cli.call(:echo_marshal, MarshalDemo.new("ok"))
+		assert_equal(result.value, "ok")
+
+		cli.close
+		svr.stop
+	end
+
+	def test_modify_marshal
+		svr, cli = start_server
+
+		result = cli.call(:modify_marshal, MarshalDemo.new("fail"))
+		assert_equal(result.value, "ok")
+
+		cli.close
+		svr.stop
+	end
+
+	def test_remote_marshal
+		svr, cli = start_server
+
+		result = cli.call(:remote_marshal)
+		assert_equal(result.value, "ok")
+
+		cli.close
+		svr.stop
+	end
+end
+


### PR DESCRIPTION
Hi there,

this patch adds MessagePack::RPC::Marshal::Client, MessagePack::RPC::Marshal::SessionPool and MessagePack::RPC::Marshal::Server which work as drop-in replacements for the regular Client/SessionPool/Server.

When used they Marshal.dump/load all method parameters and return values transparently, so two ruby endpoints can freely exchange instances of any Classes that exist on both sides, without doing any manual serialization.

The included unit-tests inherit from the standard testsuite. That means when new tests are added for the regular Classes then these tests will automatically also run for the Marshal variants, in order to avoid future regressions.

Cheers, moe
