### PR TITLE
Updated to work with Go release version 58 or higher

### DIFF
--- a/go/rpc/client.go
+++ b/go/rpc/client.go
@@ -1,127 +1,152 @@
 package rpc
 
 import (
-    "os"
-    "io"
-    "fmt"
-    "net"
-    "msgpack"
-    "reflect"
+	"os"
+	"io"
+	"fmt"
+	"net"
+	"msgpack"
+	"reflect"
 )
 
 type Session struct {
-    conn net.Conn
-    autoCoercing bool
-    nextId int
+	conn         net.Conn
+	autoCoercing bool
+	nextId       int
 }
 
 func coerce(arguments []interface{}) []interface{} {
-    _arguments := make([]interface{}, len(arguments))
-    for i, v := range arguments {
-        switch _v := v.(type) {
-        case string:
-            _arguments[i] = []byte(_v)
-        default:
-            _arguments[i] = _v
-        }
-    }
-    return _arguments
+	_arguments := make([]interface{}, len(arguments))
+	for i, v := range arguments {
+		switch _v := v.(type) {
+		case string:
+			_arguments[i] = []byte(_v)
+		default:
+			_arguments[i] = _v
+		}
+	}
+	return _arguments
 }
 
 // Sends a RPC request to the server.
 func (self *Session) SendV(funcName string, arguments []interface{}) (reflect.Value, *Error) {
-    var msgId = self.nextId
-    self.nextId += 1
-    if self.autoCoercing { arguments = coerce(arguments) }
-    err := SendRequestMessage(self.conn.(io.Writer), msgId, funcName, arguments)
-    if err != nil {
-        return nil, &Error { err, "Failed to send a request message" }
-    }
-    _msgId, result, _err := ReceiveResponse(self.conn.(io.Reader))
-    if err != nil {
-        return nil, _err
-    }
-    if msgId != _msgId {
-        return nil, &Error { nil, fmt.Sprintf("Message IDs don't match (%d != %d)", msgId, _msgId) }
-    }
-    if self.autoCoercing {
-        _result, ok := result.(reflect.ArrayOrSliceValue)
-        if ok {
-            elemType, ok := _result.Type().(reflect.ArrayOrSliceType).Elem().(*reflect.UintType)
-            if ok && elemType.Kind() == reflect.Uint8 {
-                result = reflect.NewValue(string(_result.Interface().([]byte)))
-            }
-        }
-    }
-    return result, nil
+	var msgId = self.nextId
+	self.nextId += 1
+	if self.autoCoercing {
+		arguments = coerce(arguments)
+	}
+	err := SendRequestMessage(self.conn.(io.Writer), msgId, funcName, arguments)
+	if err != nil {
+		return reflect.Value{}, &Error{err, "Failed to send a request message"}
+	}
+	_msgId, result, _err := ReceiveResponse(self.conn.(io.Reader))
+	if err != nil {
+		return reflect.Value{}, _err
+	}
+	if msgId != _msgId {
+		return reflect.Value{}, &Error{nil, fmt.Sprintf("Message IDs don't match (%d != %d)", msgId, _msgId)}
+	}
+	if self.autoCoercing {
+		_result := result
+		if _result.Kind() == reflect.Array || _result.Kind() == reflect.Slice {
+			elemType := _result.Type().Elem()
+			if (elemType.Kind() == reflect.Uint || elemType.Kind() == reflect.Uint8 || elemType.Kind() == reflect.Uint16 || elemType.Kind() == reflect.Uint32 || elemType.Kind() == reflect.Uint64 || elemType.Kind() == reflect.Uintptr) &&
+				elemType.Kind() == reflect.Uint8 {
+				result = reflect.ValueOf(string(_result.Interface().([]byte)))
+			}
+		}
+	}
+	return result, nil
 }
 
 // Sends a RPC request to the server.
 func (self *Session) Send(funcName string, arguments ...interface{}) (reflect.Value, *Error) {
-    return self.SendV(funcName, arguments)
+	return self.SendV(funcName, arguments)
 }
 
 // Creates a new session with the specified connection.  Strings are
 // automatically converted into raw bytes if autoCoercing is
 // enabled.
 func NewSession(conn net.Conn, autoCoercing bool) *Session {
-    return &Session { conn, autoCoercing, 1 };
+	return &Session{conn, autoCoercing, 1}
 }
 
 // This is a low-level function that is not supposed to be called directly
 // by the user.  Change this if the MessagePack protocol is updated.
 func SendRequestMessage(writer io.Writer, msgId int, funcName string, arguments []interface{}) os.Error {
-    _, err := writer.Write([]byte{ 0x94 })
-    if err != nil { return err }
-    _, err = msgpack.PackInt(writer, REQUEST)
-    if err != nil { return err }
-    _, err = msgpack.PackInt(writer, msgId)
-    if err != nil { return err }
-    _, err = msgpack.PackBytes(writer, []byte(funcName))
-    if err != nil { return err }
-    _, err = msgpack.PackArray(writer, reflect.NewValue(arguments).(reflect.ArrayOrSliceValue))
-    return err
+	_, err := writer.Write([]byte{0x94})
+	if err != nil {
+		return err
+	}
+	_, err = msgpack.PackInt(writer, REQUEST)
+	if err != nil {
+		return err
+	}
+	_, err = msgpack.PackInt(writer, msgId)
+	if err != nil {
+		return err
+	}
+	_, err = msgpack.PackBytes(writer, []byte(funcName))
+	if err != nil {
+		return err
+	}
+	_, err = msgpack.PackArray(writer, reflect.ValueOf(arguments))
+	return err
 }
 
 // This is a low-level function that is not supposed to be called directly
 // by the user.  Change this if the MessagePack protocol is updated.
 func ReceiveResponse(reader io.Reader) (int, reflect.Value, *Error) {
-    data, _, err := msgpack.UnpackReflected(reader)
-    if err != nil {
-        return 0, nil, &Error { nil, "Error occurred while receiving a response" }
-    }
+	data, _, err := msgpack.UnpackReflected(reader)
+	if err != nil {
+		return 0, reflect.Value{}, &Error{nil, "Error occurred while receiving a response"}
+	}
 
-    msgId, result, _err := HandleRPCResponse(data)
-    if _err != nil {
-        return 0, nil, _err
-    }
-    return msgId, result, nil
+	msgId, result, _err := HandleRPCResponse(data)
+	if _err != nil {
+		return 0, reflect.Value{}, _err
+	}
+	return msgId, result, nil
 }
 
 // This is a low-level function that is not supposed to be called directly
 // by the user.  Change this if the MessagePack protocol is updated.
 func HandleRPCResponse(req reflect.Value) (int, reflect.Value, *Error) {
-    _req, ok := req.Interface().([]reflect.Value)
-    if !ok { goto err }
-    if len(_req) != 4 { goto err }
-    msgType, ok := _req[0].(*reflect.IntValue)
-    if !ok { goto err }
-    msgId, ok := _req[1].(*reflect.IntValue)
-    if !ok { goto err }
-    if _req[2] != nil {
-        _errorMsg, ok := _req[2].(reflect.ArrayOrSliceValue)
-        if ok {
-            errorMsg, ok := _errorMsg.Interface().([]uint8)
-            if !ok { goto err }
-            if msgType.Get() != RESPONSE { goto err }
-            if errorMsg != nil {
-                return int(msgId.Get()), nil, &Error{ nil, string(errorMsg) }
-            }
-        } else {
-            goto err
-        }
-    }
-    return int(msgId.Get()), _req[3], nil
+	_req, ok := req.Interface().([]reflect.Value)
+	var msgType, msgId reflect.Value
+	if !ok {
+		goto err
+	}
+	if len(_req) != 4 {
+		goto err
+	}
+	msgType = _req[0]
+	ok = msgType.Kind() == reflect.Int || msgType.Kind() == reflect.Int8 || msgType.Kind() == reflect.Int16 || msgType.Kind() == reflect.Int32 || msgType.Kind() == reflect.Int64
+	if !ok {
+		goto err
+	}
+	msgId = _req[1]
+	if msgId.Kind() != reflect.Int && msgId.Kind() != reflect.Int8 && msgId.Kind() != reflect.Int16 && msgId.Kind() != reflect.Int32 && msgId.Kind() != reflect.Int64 {
+		goto err
+	}
+	if _req[2].IsValid() {
+		_errorMsg := _req[2]
+		if _errorMsg.Kind() == reflect.Array || _errorMsg.Kind() == reflect.Slice {
+			errorMsg, ok := _errorMsg.Interface().([]uint8)
+			if !ok {
+				goto err
+			}
+			if msgType.Int() != RESPONSE {
+				goto err
+			}
+			if errorMsg != nil {
+				return int(msgId.Int()), reflect.Value{}, &Error{nil, string(errorMsg)}
+			}
+		} else {
+			goto err
+		}
+	}
+	return int(msgId.Int()), _req[3], nil
 err:
-    return 0, nil, &Error{ nil, "Invalid message format" }
+	return 0, reflect.Value{}, &Error{nil, "Invalid message format"}
 }

--- a/go/rpc/rpc.go
+++ b/go/rpc/rpc.go
@@ -1,24 +1,24 @@
 package rpc
 
 import (
-    "reflect"
+	"reflect"
 )
 
 const (
-    REQUEST = 0
-    RESPONSE = 1
-    NOTIFICATION = 2
+	REQUEST      = 0
+	RESPONSE     = 1
+	NOTIFICATION = 2
 )
 
 type Error struct {
-    Cause interface {}
-    Message string
+	Cause   interface{}
+	Message string
 }
 
 type FunctionResolver interface {
-    Resolve(name string, arguments []reflect.Value) (*reflect.FuncValue, *Error)
+	Resolve(name string, arguments []reflect.Value) (reflect.Value, *Error)
 }
 
 func (self *Error) String() string {
-    return self.Message
+	return self.Message
 }

--- a/go/rpc/server.go
+++ b/go/rpc/server.go
@@ -1,241 +1,279 @@
 package rpc
 
 import (
-    "os"
-    "io"
-    "log"
-    "net"
-    "fmt"
-    "msgpack"
-    "container/vector"
-    "reflect"
-);
+	"os"
+	"io"
+	"log"
+	"net"
+	"fmt"
+	"msgpack"
+	"container/vector"
+	"reflect"
+)
 
 type stringizable interface {
-    String() string
+	String() string
 }
 
 type Server struct {
-    resolver FunctionResolver
-    log *log.Logger
-    listeners vector.Vector
-    autoCoercing bool
-    lchan chan int
+	resolver     FunctionResolver
+	log          *log.Logger
+	listeners    vector.Vector
+	autoCoercing bool
+	lchan        chan int
 }
 
 // Goes into the event loop to get ready to serve.
 func (self *Server) Run() *Server {
-    lchan := make(chan int)
-    self.listeners.Do(func(listener interface {}) {
-        _listener := listener.(net.Listener)
-        go (func() {
-            for {
-                conn, err := _listener.Accept()
-                if err != nil {
-                    self.log.Println(err.String())
-                    continue
-                }
-                if self.lchan == nil {
-                    conn.Close()
-                    break
-                }
-                go (func() {
-                    for {
-                        data, _, err := msgpack.UnpackReflected(conn)
-                        if err == os.EOF {
-                            break;
-                        } else if err != nil {
-                            self.log.Println(err.String())
-                            break
-                        }
-                        msgId, funcName, _arguments, xerr := HandleRPCRequest(data)
-                        if xerr != nil {
-                            self.log.Println(xerr.String())
-                            break
-                        }
-                        f, xerr := self.resolver.Resolve(funcName, _arguments)
-                        if xerr != nil {
-                            msg := xerr.String()
-                            self.log.Println(msg)
-                            SendErrorResponseMessage(conn, msgId, msg)
-                        }
-                        funcType := f.Type().(*reflect.FuncType)
-                        if funcType.NumIn() != len(_arguments) {
-                            msg := fmt.Sprintf("The number of the given arguments (%d) doesn't match the arity (%d)", len(_arguments), funcType.NumIn())
-                            self.log.Println(msg)
-                            SendErrorResponseMessage(conn, msgId, msg)
-                            goto next
-                        }
-                        if funcType.NumOut() != 1 && funcType.NumOut() != 2 {
-                            self.log.Println("The number of return values must be 1 or 2")
-                            SendErrorResponseMessage(conn, msgId, "Internal server error")
-                            goto next
-                        }
-                        var arguments []reflect.Value
-                        if self.autoCoercing {
-                            arguments = make([]reflect.Value, funcType.NumIn())
-                            for i, v := range _arguments {
-                                ft := funcType.In(i)
-                                vt := v.Type()
-                                if ft == vt {
-                                    arguments[i] = v
-                                } else {
-                                    if ft.(*reflect.StringType) != nil {
-                                        _vt, ok := v.Type().(reflect.ArrayOrSliceType)
-                                        if ok {
-                                            et := _vt.Elem().(*reflect.UintType)
-                                            if et != nil && et.Kind() == reflect.Uint8 {
-                                                arguments[i] = reflect.NewValue(string(v.Interface().([]byte)))
-                                                continue
-                                            }
-                                        }
-                                    }
-                                    msg := fmt.Sprintf("The type of argument #%d doesn't match (%s expected, got %s)", i, ft.String(), vt.String())
-                                    self.log.Println(msg)
-                                    SendErrorResponseMessage(conn, msgId, msg)
-                                    goto next
-                                }
-                            }
-                        } else {
-                            for i, v := range _arguments {
-                                ft := funcType.In(i)
-                                vt := v.Type()
-                                if ft != vt {
-                                    msg := fmt.Sprintf("The type of argument #%d doesn't match (%s expected, got %s)", i, ft.String(), vt.String())
-                                    self.log.Println(msg)
-                                    SendErrorResponseMessage(conn, msgId, msg)
-                                    goto next
-                                }
-                            }
-                            arguments = _arguments
-                        }
-                        retvals := f.Call(arguments)
-                        if funcType.NumOut() == 2 {
-                            var errMsg stringizable = nil
-                            var ok bool
-                            _errMsg := retvals[1].Interface()
-                            if _errMsg != nil {
-                                errMsg, ok = _errMsg.(stringizable)
-                                if !ok {
-                                    self.log.Println("The second argument must have an interface { String() string }")
-                                    SendErrorResponseMessage(conn, msgId, "Internal server error")
-                                    goto next
-                                }
-                            }
-                            if errMsg == nil {
-                                if self.autoCoercing {
-                                    _retval, ok := retvals[0].(*reflect.StringValue)
-                                    if ok {
-                                        retvals[0] = reflect.NewValue([]byte(_retval.Get()))
-                                    }
-                                }
-                                SendResponseMessage(conn, msgId, retvals[0])
-                            } else {
-                                SendErrorResponseMessage(conn, msgId, errMsg.String())
-                            }
-                        } else {
-                            SendResponseMessage(conn, msgId, retvals[0])
-                        }
-                    next:
-                    }
-                    conn.Close()
-                })()
-            }
-        })()
-    });
-    self.lchan = lchan
-    <-lchan
-    self.listeners.Do(func(listener interface {}) {
-        listener.(net.Listener).Close()
-    })
-    return self
+	lchan := make(chan int)
+	self.listeners.Do(func(listener interface{}) {
+		_listener := listener.(net.Listener)
+		go (func() {
+			for {
+				conn, err := _listener.Accept()
+				if err != nil {
+					self.log.Println(err.String())
+					continue
+				}
+				if self.lchan == nil {
+					conn.Close()
+					break
+				}
+				go (func() {
+					for {
+						data, _, err := msgpack.UnpackReflected(conn)
+                        var arguments, retvals []reflect.Value
+						if err == os.EOF {
+							break
+						} else if err != nil {
+							self.log.Println(err.String())
+							break
+						}
+						msgId, funcName, _arguments, xerr := HandleRPCRequest(data)
+						if xerr != nil {
+							self.log.Println(xerr.String())
+							break
+						}
+						f, xerr := self.resolver.Resolve(funcName, _arguments)
+						if xerr != nil {
+							msg := xerr.String()
+							self.log.Println(msg)
+							SendErrorResponseMessage(conn, msgId, msg)
+						}
+						funcType := f.Type()
+						if funcType.NumIn() != len(_arguments) {
+							msg := fmt.Sprintf("The number of the given arguments (%d) doesn't match the arity (%d)", len(_arguments), funcType.NumIn())
+							self.log.Println(msg)
+							SendErrorResponseMessage(conn, msgId, msg)
+							goto next
+						}
+						if funcType.NumOut() != 1 && funcType.NumOut() != 2 {
+							self.log.Println("The number of return values must be 1 or 2")
+							SendErrorResponseMessage(conn, msgId, "Internal server error")
+							goto next
+						}
+
+						if self.autoCoercing {
+							arguments = make([]reflect.Value, funcType.NumIn())
+							for i, v := range _arguments {
+								ft := funcType.In(i)
+								vt := v.Type()
+								if ft == vt {
+									arguments[i] = v
+								} else {
+									if ft != nil {
+										_vt := v.Type()
+										if _vt.Kind() == reflect.Array || _vt.Kind() == reflect.Slice {
+											et := _vt.Elem()
+											if et != nil && et.Kind() == reflect.Uint8 {
+												arguments[i] = reflect.ValueOf(string(v.Interface().([]byte)))
+												continue
+											}
+										}
+									}
+									msg := fmt.Sprintf("The type of argument #%d doesn't match (%s expected, got %s)", i, ft.String(), vt.String())
+									self.log.Println(msg)
+									SendErrorResponseMessage(conn, msgId, msg)
+									goto next
+								}
+							}
+						} else {
+							for i, v := range _arguments {
+								ft := funcType.In(i)
+								vt := v.Type()
+								if ft != vt {
+									msg := fmt.Sprintf("The type of argument #%d doesn't match (%s expected, got %s)", i, ft.String(), vt.String())
+									self.log.Println(msg)
+									SendErrorResponseMessage(conn, msgId, msg)
+									goto next
+								}
+							}
+							arguments = _arguments
+						}
+						retvals = f.Call(arguments)
+						if funcType.NumOut() == 2 {
+							var errMsg stringizable = nil
+							var ok bool
+							_errMsg := retvals[1].Interface()
+							if _errMsg != nil {
+								errMsg, ok = _errMsg.(stringizable)
+								if !ok {
+									self.log.Println("The second argument must have an interface { String() string }")
+									SendErrorResponseMessage(conn, msgId, "Internal server error")
+									goto next
+								}
+							}
+							if errMsg == nil {
+								if self.autoCoercing {
+									_retval := retvals[0]
+									if _retval.Kind() == reflect.String {
+										retvals[0] = reflect.ValueOf([]byte(_retval.String()))
+									}
+								}
+								SendResponseMessage(conn, msgId, retvals[0])
+							} else {
+								SendErrorResponseMessage(conn, msgId, errMsg.String())
+							}
+						} else {
+							SendResponseMessage(conn, msgId, retvals[0])
+						}
+					next:
+					}
+					conn.Close()
+				})()
+			}
+		})()
+	})
+	self.lchan = lchan
+	<-lchan
+	self.listeners.Do(func(listener interface{}) {
+		listener.(net.Listener).Close()
+	})
+	return self
 }
 
 // Lets the server quit the event loop
 func (self *Server) Stop() *Server {
-    if self.lchan != nil {
-        lchan := self.lchan
-        self.lchan = nil
-        lchan <- 1
-    }
-    return self
+	if self.lchan != nil {
+		lchan := self.lchan
+		self.lchan = nil
+		lchan <- 1
+	}
+	return self
 }
 
 // Listenes on the specified transport.  A single server can listen on the
 // multiple ports.
-func (self *Server) Listen(listener net.Listener) *Server{
-    self.listeners.Push(listener)
-    return self
+func (self *Server) Listen(listener net.Listener) *Server {
+	self.listeners.Push(listener)
+	return self
 }
 
 // Creates a new Server instance. raw bytesc are automatically converted into
 // strings if autoCoercing is enabled.
 func NewServer(resolver FunctionResolver, autoCoercing bool, _log *log.Logger) *Server {
-    if _log == nil {
-        _log = log.New(os.Stderr, "msgpack", log.Ldate | log.Ltime)
-    }
-    return &Server { resolver, _log, vector.Vector {}, autoCoercing, nil }
+	if _log == nil {
+		_log = log.New(os.Stderr, "msgpack", log.Ldate|log.Ltime)
+	}
+	return &Server{resolver, _log, vector.Vector{}, autoCoercing, nil}
 }
 
 // This is a low-level function that is not supposed to be called directly
 // by the user.  Change this if the MessagePack protocol is updated.
 func HandleRPCRequest(req reflect.Value) (int, string, []reflect.Value, *Error) {
-    _req, ok := req.Interface().([]reflect.Value)
-    if !ok { goto err }
-    if len(_req) != 4 { goto err }
-    msgType, ok := _req[0].(*reflect.IntValue)
-    if !ok { goto err }
-    msgId, ok := _req[1].(*reflect.IntValue)
-    if !ok { goto err }
-    _funcName, ok := _req[2].(reflect.ArrayOrSliceValue)
-    if !ok { goto err }
-    funcName, ok := _funcName.Interface().([]uint8)
-    if !ok { goto err }
-    if msgType.Get() != REQUEST { goto err }
-    _arguments, ok := _req[3].(reflect.ArrayOrSliceValue)
+	_req, ok := req.Interface().([]reflect.Value)
+    var msgType, msgId, _funcName, _arguments reflect.Value
+    var funcName []uint8
     var arguments []reflect.Value
-    if ok {
-        elemType := _req[3].Type().(reflect.ArrayOrSliceType).Elem()
-        _elemType, ok := elemType.(*reflect.UintType)
-        if !ok || _elemType.Kind() != reflect.Uint8 {
-            arguments, ok = _arguments.Interface().([]reflect.Value)
-        } else {
-            arguments = []reflect.Value { reflect.NewValue(string(_req[3].Interface().([]byte))) }
-        }
-    } else {
-        arguments = []reflect.Value { _req[3] }
-    }
-    return int(msgId.Get()), string(funcName), arguments, nil
+	if !ok {
+		goto err
+	}
+	if len(_req) != 4 {
+		goto err
+	}
+	msgType = _req[0]
+	ok = msgType.Kind() == reflect.Int || msgType.Kind() == reflect.Int8 || msgType.Kind() == reflect.Int16 || msgType.Kind() == reflect.Int32 || msgType.Kind() == reflect.Int64
+	if !ok {
+		goto err
+	}
+	msgId = _req[1]
+	ok = msgId.Kind() == reflect.Int || msgId.Kind() == reflect.Int8 || msgId.Kind() == reflect.Int16 || msgId.Kind() == reflect.Int32 || msgId.Kind() == reflect.Int64
+	if !ok {
+		goto err
+	}
+	_funcName = _req[2]
+	ok = _funcName.Kind() == reflect.Array || _funcName.Kind() == reflect.Slice
+	if !ok {
+		goto err
+	}
+	funcName, ok = _funcName.Interface().([]uint8)
+	if !ok {
+		goto err
+	}
+	if msgType.Int() != REQUEST {
+		goto err
+	}
+	_arguments = _req[3]
+
+	if _arguments.Kind() == reflect.Array || _arguments.Kind() == reflect.Slice {
+		elemType := _req[3].Type().Elem()
+		_elemType := elemType
+		ok = _elemType.Kind() == reflect.Uint || _elemType.Kind() == reflect.Uint8 || _elemType.Kind() == reflect.Uint16 || _elemType.Kind() == reflect.Uint32 || _elemType.Kind() == reflect.Uint64 || _elemType.Kind() == reflect.Uintptr
+		if !ok || _elemType.Kind() != reflect.Uint8 {
+			arguments, ok = _arguments.Interface().([]reflect.Value)
+		} else {
+			arguments = []reflect.Value{reflect.ValueOf(string(_req[3].Interface().([]byte)))}
+		}
+	} else {
+		arguments = []reflect.Value{_req[3]}
+	}
+	return int(msgId.Int()), string(funcName), arguments, nil
 err:
-    return 0, "", nil, &Error{ nil, "Invalid message format" }
+	return 0, "", nil, &Error{nil, "Invalid message format"}
 }
 
 // This is a low-level function that is not supposed to be called directly
 // by the user.  Change this if the MessagePack protocol is updated.
 func SendResponseMessage(writer io.Writer, msgId int, value reflect.Value) os.Error {
-    _, err := writer.Write([]byte{ 0x94 })
-    if err != nil { return err }
-    _, err = msgpack.PackInt8(writer, RESPONSE)
-    if err != nil { return err }
-    _, err = msgpack.PackInt(writer, msgId)
-    if err != nil { return err }
-    _, err = msgpack.PackNil(writer)
-    if err != nil { return err }
-    _, err = msgpack.PackValue(writer, value)
-    return err
+	_, err := writer.Write([]byte{0x94})
+	if err != nil {
+		return err
+	}
+	_, err = msgpack.PackInt8(writer, RESPONSE)
+	if err != nil {
+		return err
+	}
+	_, err = msgpack.PackInt(writer, msgId)
+	if err != nil {
+		return err
+	}
+	_, err = msgpack.PackNil(writer)
+	if err != nil {
+		return err
+	}
+	_, err = msgpack.PackValue(writer, value)
+	return err
 }
 
 // This is a low-level function that is not supposed to be called directly
 // by the user.  Change this if the MessagePack protocol is updated.
 func SendErrorResponseMessage(writer io.Writer, msgId int, errMsg string) os.Error {
-    _, err := writer.Write([]byte{ 0x94 })
-    if err != nil { return err }
-    _, err = msgpack.PackInt8(writer, RESPONSE)
-    if err != nil { return err }
-    _, err = msgpack.PackInt(writer, msgId)
-    if err != nil { return err }
-    _, err = msgpack.PackBytes(writer, []byte(errMsg))
-    if err != nil { return err }
-    _, err = msgpack.PackNil(writer)
-    return err
+	_, err := writer.Write([]byte{0x94})
+	if err != nil {
+		return err
+	}
+	_, err = msgpack.PackInt8(writer, RESPONSE)
+	if err != nil {
+		return err
+	}
+	_, err = msgpack.PackInt(writer, msgId)
+	if err != nil {
+		return err
+	}
+	_, err = msgpack.PackBytes(writer, []byte(errMsg))
+	if err != nil {
+		return err
+	}
+	_, err = msgpack.PackNil(writer)
+	return err
 }

--- a/go/rpc/server_test.go
+++ b/go/rpc/server_test.go
@@ -1,48 +1,52 @@
 package msgpack_rpc_test
 
 import (
-    . "msgpack/rpc"
-    "testing"
-    "net"
-    "reflect"
+	. "msgpack/rpc"
+	"testing"
+	"net"
+	"reflect"
 )
 
-type Resolver map[string] *reflect.FuncValue
+type Resolver map[string]reflect.Value
 
-func (self Resolver) Resolve(name string, arguments []reflect.Value) (*reflect.FuncValue, *Error) {
-    return self[name], nil
+func (self Resolver) Resolve(name string, arguments []reflect.Value) (reflect.Value, *Error) {
+	return self[name], nil
 }
 
-func echo(test string) (string, interface{ String() string }) {
-    return "Hello, " + test, nil
+func echo(test string) (string, interface {
+	String() string
+}) {
+	return "Hello, " + test, nil
 }
 
 func TestRun(t *testing.T) {
-    res := Resolver{ "echo": reflect.NewValue(echo).(*reflect.FuncValue) }
-    serv := NewServer(res, true, nil)
-    l, err := net.Listen("tcp", "127.0.0.1:50000")
-    if err != nil {
-        t.Fail()
-        return
-    }
-    serv.Listen(l)
-    go (func() { serv.Run() })()
-    conn, err := net.Dial("tcp", "", "127.0.0.1:50000")
-    if err != nil {
-        t.Fail()
-        return
-    }
-    client := NewSession(conn, true)
-    for _, v := range []string { "world", "test", "hey" } {
-        retval, xerr := client.Send("echo", v)
-        if xerr != nil {
-            t.Error(xerr.String())
-            return
-        }
-        _retval, ok := retval.(*reflect.StringValue)
-        if !ok {
-            return
-        }
-        if _retval.Get() != "Hello, " + v { t.Error("retval != \"Hello, " + v + "\"") }
-    }
+	res := Resolver{"echo": reflect.ValueOf(echo)}
+	serv := NewServer(res, true, nil)
+	l, err := net.Listen("tcp", "127.0.0.1:50000")
+	if err != nil {
+		t.Fail()
+		return
+	}
+	serv.Listen(l)
+	go (func() { serv.Run() })()
+	conn, err := net.Dial("tcp", "127.0.0.1:50000")
+	if err != nil {
+		t.Fail()
+		return
+	}
+	client := NewSession(conn, true)
+	for _, v := range []string{"world", "test", "hey"} {
+		retval, xerr := client.Send("echo", v)
+		if xerr != nil {
+			t.Error(xerr.String())
+			return
+		}
+		_retval := retval
+		if _retval.Kind() != reflect.String {
+			return
+		}
+		if _retval.String() != "Hello, "+v {
+			t.Error("retval != \"Hello, " + v + "\"")
+		}
+	}
 }


### PR DESCRIPTION
Updated reflection code to work with the newly changed reflection APIs in Go version 58 and higher.  Also works with weekly and tip versions of Go.
