### PR TITLE
[Python]Fix TypeError Exception when test/echoserver.py run

### DIFF
--- a/python/test/echoserver.py
+++ b/python/test/echoserver.py
@@ -47,5 +47,5 @@ def serve(daemon=False):
             pass
 
 if __name__ == '__main__':
-    port = serve(False)
+    server, port = serve(False)
     print "Serving on localhost:%d\n" % (port,)


### PR DESCRIPTION
Hi,
I got TypeError exception when I start ran python/test/echoserver.py standalone.

`$ python echoserver.py`

Traceback (most recent call last):
  File "echoserver.py", line 51, in <module>
    print "Serving on localhost:%d\n" % (port,)
TypeError: %d format: a number is required, not tuple

I just wrote patch to test/echoserver.py .

Regards,
