### PR TITLE
Fix to yield reactor loop after sending data so async calls are dispatched immediately

### DIFF
--- a/ruby/lib/msgpack/rpc/session.rb
+++ b/ruby/lib/msgpack/rpc/session.rb
@@ -188,6 +188,7 @@ class Session
 		@seqid += 1; if @seqid >= 1<<31 then @seqid = 0 end
 		data = [REQUEST, msgid, method, param].to_msgpack
 		@transport.send_data(data)
+    @loop.run_once
 		@reqtable[msgid] = Future.new(self, @loop)
 	end
 
@@ -195,6 +196,7 @@ class Session
 		method = method.to_s
 		data = [NOTIFY, method, param].to_msgpack
 		@transport.send_data(data)
+    @loop.run_once
 		nil
 	end
 end


### PR DESCRIPTION
Add a call to #run_once on the session loop after sending data to ensure the request is actually dispatched to the socket before moving on. This makes #call_async actually asynchronous (previously the request was not actually sent until #join was called on the future).

Also resolves Issue #25.
