### PR TITLE
a client can proxy all methods on an interface, including parent interfaces

### DIFF
--- a/java/src/main/java/org/msgpack/rpc/reflect/MethodSelector.java
+++ b/java/src/main/java/org/msgpack/rpc/reflect/MethodSelector.java
@@ -34,7 +34,7 @@ public class MethodSelector {
 
 	public static Method[] selectRpcClientMethod(Class<?> iface) {
 		List<Method> methods = new ArrayList();
-		for(Method method : iface.getDeclaredMethods()) {
+		for(Method method : iface.getMethods()) {
 			if(isRpcClientMethod(method)) {
 				methods.add(method);
 			}


### PR DESCRIPTION
Hiya, 

I've modified the code (one method call) so that client proxies can use an interface that extends from another interface (Class#getMethods(), not Class#getDeclaredMethods()). this is valuable because the client and the server might share a simialar interface, but, for example, the server might implement hello as hello( Result result, String s) and the client might implement it as Future<String> etc. The tests all pass in this case and I can't see - tracing through the proxy building code - how this would fail. 
