### PR TITLE
Add Callback abstraction to prevent exposure of Request object on RPC method signature

### DIFF
--- a/java/src/main/java/org/msgpack/rpc/Callback.java
+++ b/java/src/main/java/org/msgpack/rpc/Callback.java
@@ -1,0 +1,55 @@
+//
+// MessagePack-RPC for Java
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+package org.msgpack.rpc;
+
+/**
+ * Callback interface for RPC methods. Use this interface to mark a method
+ * exposed on a RPC handler as asynchronous. If the methods first parameter is
+ * assignable from {@link Callback} the server won't explicitly wait for the
+ * methods execution, instead the executed method is responsible for triggering
+ * a response by calling one of the callbacks methods.
+ * <p>
+ * Example:
+ * 
+ * <pre>
+ *   class RPCServer {
+ *     public void doAsync(Callback<String> callback, String action) {
+ *       // do some action
+ *       if (success) 
+ *         callback.run(actionResult);
+ *       else
+ *         callback.onError(null, "failed"):
+ *     }
+ * </pre>
+ */
+public interface Callback<T> {
+
+    /**
+     * Passes the methods result back to the caller.
+     * 
+     * @param result the methods result
+     */
+    public void run(T result);
+
+    /**
+     * Passes the result and an object representing the error back to the caller
+     * in the case of an exception.
+     * 
+     * @param result the result if any
+     * @param error the error
+     */
+    public void onError(T result, Object error);
+}

--- a/java/src/main/java/org/msgpack/rpc/Request.java
+++ b/java/src/main/java/org/msgpack/rpc/Request.java
@@ -21,7 +21,7 @@ import org.msgpack.MessagePackObject;
 import org.msgpack.rpc.message.ResponseMessage;
 import org.msgpack.rpc.transport.MessageSendable;
 
-public class Request {
+public class Request implements Callback<Object>{
 	private MessageSendable channel;  // synchronized?
 	private int msgid;
 	private String method;
@@ -74,5 +74,13 @@ public class Request {
 		channel.sendMessage(msg);
 		channel = null;
 	}
+
+    public void onError(Object result, Object error) {
+        sendResponse(result, error);
+    }
+
+    public void run(Object result) {
+        sendResult(result);
+    }
 }
 

--- a/java/src/main/java/org/msgpack/rpc/reflect/InvokerBuilder.java
+++ b/java/src/main/java/org/msgpack/rpc/reflect/InvokerBuilder.java
@@ -24,6 +24,7 @@ import java.lang.annotation.*;
 import org.msgpack.annotation.*;
 import org.msgpack.*;
 import org.msgpack.template.*;
+import org.msgpack.rpc.Callback;
 import org.msgpack.rpc.Request;
 
 public abstract class InvokerBuilder {
@@ -168,8 +169,8 @@ public abstract class InvokerBuilder {
 	//}
 
 	static boolean isAsyncMethod(Method targetMethod) {
-		Type[] types = targetMethod.getParameterTypes();
-		return types.length > 0 && types[0].equals(Request.class);
+		final Class<?>[] types = targetMethod.getParameterTypes();
+		return types.length > 0 && Callback.class.isAssignableFrom(types[0]);
 	}
 
 

--- a/java/src/test/java/org/msgpack/rpc/reflect/ReflectTest.java
+++ b/java/src/test/java/org/msgpack/rpc/reflect/ReflectTest.java
@@ -82,30 +82,30 @@ public abstract class ReflectTest extends TestCase {
 	}
 
 	public static class AsyncHandler {
-		public void m01(Request request) {
-			request.sendResult("m01");
-		}
+        public void m01(Callback<String> callback) {
+            callback.run("m01");
+        }
 
-		public void m02(Request request, String a1) {
-			request.sendResult("m02"+a1);
-		}
+        public void m02(Callback<String> callback, String a1) {
+            callback.run("m02"+a1);
+        }
 
-		public void m03(Request request, int a1) {
-			request.sendResult("m03"+a1);
-		}
+        public void m03(Callback<String> callback, int a1) {
+            callback.run("m03"+a1);
+        }
 
-		public void m04(Request request, List<String> a1) {
-			request.sendResult("m04"+stringify1(a1));
-		}
+        public void m04(Callback<String> callback, List<String> a1) {
+            callback.run("m04"+stringify1(a1));
+        }
 
-		public void m05(Request request, List<List<String>> a1) {
-			request.sendResult("m05"+stringify2(a1));
-		}
+        public void m05(Callback<String> callback, List<List<String>> a1) {
+            callback.run("m05"+stringify2(a1));
+        }
 
-		public void m06(Request request, String a1, int a2) {
-			request.sendResult("m06"+a1+a2);
-		}
-	}
+        public void m06(Callback<String> callback, String a1, int a2) {
+            callback.run("m06"+a1+a2);
+        }
+    }
 
 	static class Context {
 		Server server;


### PR DESCRIPTION
I use msgpack to call services on either local or remote machines. Yet, if the service I want to call is local I need to create a Request object if I want to expose the interface I use for the server directly. With a callback instead of Request as a marker for async methods this gets way cleaner while users don't loose any functionality. 

I simply made Request implement Callback<T> which still allows users to use Request in their method signature instead of callback if they need to and/or for backwards compatibility reasons.
