### PR TITLE
ruby: replaced Rev with Cool.io

### DIFF
--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -14,7 +14,7 @@ begin
 		gemspec.has_rdoc = true
 		gemspec.require_paths = ["lib"]
 		gemspec.add_dependency "msgpack", ">= 0.4.4"
-		gemspec.add_dependency "rev", ">= 0.3.0"
+		gemspec.add_dependency "cool.io", ">= 1.0.0"
 		gemspec.test_files = Dir["test/test_*.rb"]
 		gemspec.files = Dir["lib/**/*", "ext/**/*", "test/**/*", "spec/**/*", "tasks/**/*"] + %w[AUTHORS ChangeLog NOTICE README]
 		gemspec.add_development_dependency('rspec')

--- a/ruby/lib/msgpack/rpc.rb
+++ b/ruby/lib/msgpack/rpc.rb
@@ -233,7 +233,7 @@ end  # module MessagePack
 
 require 'msgpack'
 require 'socket'
-require 'rev'
+require 'cool.io'
 require 'msgpack/rpc/version'
 require 'msgpack/rpc/address'
 require 'msgpack/rpc/message'

--- a/ruby/lib/msgpack/rpc/loop.rb
+++ b/ruby/lib/msgpack/rpc/loop.rb
@@ -19,13 +19,13 @@ module MessagePack
 module RPC
 
 
-Loop = Rev::Loop
+Loop = Cool.io::Loop
 
 
 module LoopUtil
 	attr_reader :loop
 
-	class Timer < Rev::TimerWatcher
+	class Timer < Cool.io::TimerWatcher
 		def initialize(interval, repeating, &block)
 			@block = block
 			super(interval, repeating)
@@ -39,7 +39,7 @@ module LoopUtil
 		@loop.attach Timer.new(interval, repeating, &block)
 	end
 
-	class TaskQueue < Rev::AsyncWatcher
+	class TaskQueue < Cool.io::AsyncWatcher
 		def initialize
 			@queue = []
 			super
@@ -77,7 +77,7 @@ module LoopUtil
 		@queue.detach if @queue && @queue.attached?
 		@loop.stop
 		# attach dummy timer
-		@loop.attach Rev::TimerWatcher.new(0, false)
+		@loop.attach Cool.io::TimerWatcher.new(0, false)
 		nil
 	end
 end

--- a/ruby/lib/msgpack/rpc/transport/tcp.rb
+++ b/ruby/lib/msgpack/rpc/transport/tcp.rb
@@ -31,13 +31,13 @@ class TCPTransport
 		TCPClientTransport.new(session, address, @reconnect_limit)
 	end
 
-	class BasicSocket < Rev::TCPSocket
+	class BasicSocket < Cool.io::TCPSocket
 		def initialize(io)
 			super(io)
 			@pac = MessagePack::Unpacker.new
 		end
 
-		# from Rev::TCPSocket
+		# from Cool.io::TCPSocket
 		def on_readable
 			super
 		rescue
@@ -46,7 +46,7 @@ class TCPTransport
 			close
 		end
 
-		# from Rev::TCPSocket
+		# from Cool.io::TCPSocket
 		def on_read(data)
 			@pac.feed_each(data) {|obj|
 				on_message(obj)
@@ -162,13 +162,13 @@ class TCPClientTransport
 			@s.on_response(self, msgid, error, result)
 		end
 
-		# from Rev::TCPSocket
+		# from Cool.io::TCPSocket
 		def on_connect
 			return unless @t
 			@t.on_connect(self)
 		end
 
-		# from Rev::TCPSocket
+		# from Cool.io::TCPSocket
 		def on_connect_failed
 			return unless @t
 			@t.on_connect_failed(self)
@@ -176,7 +176,7 @@ class TCPClientTransport
 			nil
 		end
 
-		# from Rev::TCPSocket
+		# from Cool.io::TCPSocket
 		def on_close
 			return unless @t
 			@t.on_close(self)
@@ -199,7 +199,7 @@ class TCPServerTransport
 	def listen(server)
 		@server = server
 		host, port = *@address.unpack
-		@lsock  = Rev::TCPServer.new(host, port, ServerSocket, @server)
+		@lsock  = Cool.io::TCPServer.new(host, port, ServerSocket, @server)
 		begin
 			@server.loop.attach(@lsock)
 		rescue

--- a/ruby/lib/msgpack/rpc/transport/udp.rb
+++ b/ruby/lib/msgpack/rpc/transport/udp.rb
@@ -28,7 +28,7 @@ class UDPTransport
 		UDPClientTransport.new(session, address)
 	end
 
-	class BasicSocket < Rev::IOWatcher
+	class BasicSocket < Cool.io::IOWatcher
 		HAVE_DNRL = UDPSocket.public_instance_methods.include?(:do_not_reverse_lookup)
 
 		def initialize(io)

--- a/ruby/lib/msgpack/rpc/transport/unix.rb
+++ b/ruby/lib/msgpack/rpc/transport/unix.rb
@@ -28,13 +28,13 @@ class UNIXTransport
 		UNIXClientTransport.new(session, address)
 	end
 
-	class BasicSocket < Rev::UNIXSocket
+	class BasicSocket < Cool.io::UNIXSocket
 		def initialize(io)
 			super(io)
 			@pac = MessagePack::Unpacker.new
 		end
 
-		# from Rev::TCPSocket
+		# from Cool.io::TCPSocket
 		def on_readable
 			super
 		rescue
@@ -43,7 +43,7 @@ class UNIXTransport
 			close
 		end
 
-		# from Rev::UNIXSocket
+		# from Cool.io::UNIXSocket
 		def on_read(data)
 			@pac.feed_each(data) {|obj|
 				on_message(obj)
@@ -123,7 +123,7 @@ class UNIXServerTransport
 	# ServerTransport interface
 	def listen(server)
 		@server = server
-		@lsock  = Rev::UNIXServer.new(@address, ServerSocket, @server)
+		@lsock  = Cool.io::UNIXServer.new(@address, ServerSocket, @server)
 		begin
 			@server.loop.attach(@lsock)
 		rescue


### PR DESCRIPTION
I've replaced Rev used by msgpack-rpc ruby to Cool.io. Simply renaming Rev to Cool.io worked fine. I ran test with Ruby1.8.7 and Ruby1.9.2. I haven't changed VERSION file yet, so please bump version appropriately.
