### PR TITLE
handling tuple properly

### DIFF
--- a/python/test/echoserver.py
+++ b/python/test/echoserver.py
@@ -48,4 +48,4 @@ def serve(daemon=False):
 
 if __name__ == '__main__':
     port = serve(False)
-    print "Serving on localhost:%d\n" % (port,)
+    print "Serving on localhost:%d\n" % port[1]


### PR DESCRIPTION
Traceback (most recent call last):
  File "echoserver.py", line 51, in <module>
    print "Serving on localhost:%d\n" % (port,)
TypeError: %d format: a number is required, not tuple
