### PR TITLE
[PATCH] various fix on php library (error handling and misc)

### DIFF
--- a/php/lib/Back.php
+++ b/php/lib/Back.php
@@ -1,10 +1,8 @@
 <?php
-include_once dirname(__FILE__) . '/Future.php';
+require_once dirname(__FILE__) . '/Future.php';
 
 class MessagePackRPC_Back
 {
-  public $errorMessage01 = 'Network error';
-  public $errorMessage02 = 'Objects error';
   public $size;
   public static $shared_client_socket = null;
   public $client_socket = null;
@@ -44,11 +42,11 @@ class MessagePackRPC_Back
     $size = $this->size;
     $send = $this->msgpackEncode($call);
     $sock = $this->connect($host, $port);
-    if ($sock === FALSE) throw new Exception($this->errorMessage01);
+    if ($sock === FALSE) throw new MessagePackRPC_Error_NetworkError(error_get_last());
     $puts = fputs($sock, $send);
-    if ($puts === FALSE) throw new Exception($this->errorMessage01);
+    if ($puts === FALSE) throw new MessagePackRPC_Error_NetworkError(error_get_last());
     $read = fread($sock, $size);
-    if ($read === FALSE) throw new Exception($this->errorMessage01);
+    if ($read === FALSE) throw new MessagePackRPC_Error_NetworkError(error_get_last());
     if (!$this->reuse_connection)
       fclose($sock);
 
@@ -84,7 +82,7 @@ class MessagePackRPC_Back
     $sets = $data[3];
 
     if ($type != 1) {
-      throw new Exception($this->errorMessage02);
+      throw new MessagePackRPC_Error_ProtocolError("Invalid message type for response: {$type}");
     }
 
     $feature = new MessagePackRPC_Future();
@@ -112,7 +110,7 @@ class MessagePackRPC_Back
     $data = $this->msgpackDecode($recv);
 
     if (count($data) != 4) {
-      throw new Exception($this->errorMessage02);
+      throw new MessagePackRPC_Error_ProtocolError("Invalid message structure.");
     }
 
     $type = $data[0];
@@ -121,7 +119,7 @@ class MessagePackRPC_Back
     $args = $data[3];
 
     if ($type != 0) {
-      throw new Exception($this->errorMessage02);
+      throw new MessagePackRPC_Error_ProtocolError("Invalid message type for request: {$type}");
     }
 
     return array($code, $func, $args);

--- a/php/lib/Client.php
+++ b/php/lib/Client.php
@@ -1,5 +1,5 @@
 <?php
-include_once dirname(__FILE__) . '/Back.php';
+require_once dirname(__FILE__) . '/Back.php';
 
 class MessagePackRPC_Client
 {
@@ -26,8 +26,17 @@ class MessagePackRPC_Client
     $result  = $feature->getResult();
     $errors  = $feature->getErrors();
 
-    if (0 < strlen($errors)) {
-      throw new Exception($errors);
+    if (!is_null($errors)) {
+      if (is_array($errors)) {
+	$errors = '[' . implode(', ', $errors) . ']';
+      } else if (is_object($errors)) {
+	if (method_exists($errors, '__toString')) {
+	  $errors = $errors->__toString();
+	} else {
+	  $errors = print_r($errors, true);
+	}
+      }
+      throw new MessagePackRPC_Error_RequestError("{$errors}");
     }
 
     return $result;

--- a/php/lib/Error.php
+++ b/php/lib/Error.php
@@ -1,0 +1,15 @@
+<?php
+
+class MessagePackRPC_Error extends Exception
+{
+  function __construct($msg = '', $code = null, $prev = null) {
+    if (is_array($msg) && array_key_exists('message', $msg))
+      $msg = $msg['message'];
+    parent::__construct($msg, $code, $prev);
+  }
+}
+class MessagePackRPC_Error_NetworkError extends MessagePackRPC_Error {}
+class MessagePackRPC_Error_ProtocolError extends MessagePackRPC_Error {}
+class MessagePackRPC_Error_RequestError extends MessagePackRPC_Error {}
+
+

--- a/php/lib/Future.php
+++ b/php/lib/Future.php
@@ -1,4 +1,6 @@
 <?php
+require_once dirname(__FILE__) . '/Error.php';
+
 class MessagePackRPC_Future
 {
   public $result = null;

--- a/php/test/client.php
+++ b/php/test/client.php
@@ -18,6 +18,11 @@ try {
   $client = new MessagePackRPC_Client('localhost', '1985');
   testIs('test0001', 3, $client->call('hello1', array(2)));
   testIs('test0001', 5, $client->call('hello2', array(3)));
+  try {
+    $client->call('fail', array());
+  } catch (MessagePackRPC_Error_RequestError $e) {
+    echo "OK (proper error)\n";
+  }
 } catch (Exception $e) {
   echo $e->getMessage() . "\n";
 }

--- a/php/test/server.php
+++ b/php/test/server.php
@@ -16,6 +16,11 @@ class App
   {
     return $a + 2;
   }
+
+  public function fail()
+  {
+    throw new Exception('hoge');
+  }
 }
 
 function testIs($no, $a, $b)


### PR DESCRIPTION
Hello!

I sent single pull request with recent changes.
If you convenient, I'll split the request for each features.
Plese feel free to request me if so.

Details of changes follows (ordered by priority);
## Spec violation on error handling.

I found PHP library has two violations against MessagePack RPC spec on error response.
- Treating empty string of error field of response object as success. This must be null (Nil on spec).
- User get fatal error when error is not string (e.g. object, array).

Here is a minimal fix for these problem.
(NOTE: This change breaks backward compatibility.)
## Error handling improvements
1. Add exception classes with suitable messasge

Currently the library uses base 'Exception' class directly with just two error message for any error.
So user have poor way to handle errors.

Fix by splitting exception class for each case and throw it with suitable error messasge.
1. Handle exception on backend service

PHP server always return success as response and will die
when get any exception from method call of backend service.

I worte change to handle exceptions and return error object correctly.
## Fix require chain properly.

Tiny fixes for require/include chain properly:
- Add require backend library to Server.php.
- Change to use 'require' intead of 'include'.  In the fact, library dose not work completely when include fails.
## Make sure to close server socket.

Currently Server library will leaves listen socket when
get any exception or signal. The socket will be closed
by OS after some period, but it is not convenient.

This is a simple patch to make sure to close listen socket
when finish server process.
