### PR TITLE
PHP: client message reader fix (CPU exhaust and close handling)

### DIFF
--- a/php/lib/Back.php
+++ b/php/lib/Back.php
@@ -75,7 +75,10 @@ class MessagePackRPC_Back
 
   public function readMsg($io) {
     stream_set_blocking($io, 0);
-    while (true) {
+    while (!feof($io)) {
+      $r = array($io);
+      $n = null;
+      stream_select($r, $n, $n, null);
       $read = fread($io, $this->size);
       if ($read === FALSE) throw new MessagePackRPC_Error_NetworkError(error_get_last());
       $this->unpacker->feed($read);


### PR DESCRIPTION
This change is focused on two problems of client message reader.
- When connection is slow or blocked exhaust CPU by null read cycle.
- It will continue null read even if server closed connection.

So check eof and use select() to check data is ready.
