### PR TITLE
Fix mplex for backwards compatibility with older Ruby versions

### DIFF
--- a/cpp/mplex
+++ b/cpp/mplex
@@ -141,7 +141,7 @@ begin
 
 	finputs = ARGV
 
-	raise "multiple stdin" if (finputs + [fctx]).count("-") >= 2
+	raise "multiple stdin" if (finputs + [fctx]).select {|e| e == "-"}.size >= 2
 
 rescue
 	usage


### PR DESCRIPTION
Ruby 1.8.6 and earlier don't have the count function. Some OS don't have the latest ruby installation and the script bug:

`undefined method `count' for ["src/msgpack/rpc/caller.hmpl", nil]:Array`

Replaced line 144 : 

``` ruby
(finputs + [fctx]).count("-")
```

 by 

``` ruby
(finputs + [fctx]).select {|e| e == "-"}.size
```
